### PR TITLE
Add -pypylog option for -convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ optional arguments:
 
 `-jitlog <profile.jit>` use jitlog data (only for converting vmprof data)
 
+`-pypylog <profile.pypylog>` use pypylog data (only for converting vmprof data)
+
 `--zip` export sharable zip (only for running vmprof)
 
 `--nobrowser` dont open firefox profiler
@@ -26,6 +28,14 @@ optional arguments:
 
 cpuburn code can be found
 [here](https://github.com/vmprof/vmprof-python/blob/master/vmprof/test/cpuburn.py)
+
+## Example PyPy run-and-convert w. jitlog & pypylog
+
+```bash
+$ PYPYLOG=profile.pypylog python -m vmprof --jitlog -o profile.prof <remaining vmprof args...>
+...
+$ python -m vmprofconvert -convert profile.prof -jitlog profile.prof.jit -pypylog profile.pypylog
+````
 
 #
 

--- a/vmprofconvert/__init__.py
+++ b/vmprofconvert/__init__.py
@@ -41,8 +41,9 @@ def convert_stats_with_pypylog(vmprof_path, pypylog_path, times):
     c.walk_samples(stats)
     if pypylog_path  :
         pypylog = parse_pypylog(pypylog_path)
-        total_runtime_micros = (times[1] - times[0]) * 1000000
-        pypylog = cut_pypylog(pypylog, total_runtime_micros, stats.get_runtime_in_microseconds())
+        if times is not None:
+            total_runtime_micros = (times[1] - times[0]) * 1000000
+            pypylog = cut_pypylog(pypylog, total_runtime_micros, stats.get_runtime_in_microseconds())
         pypylog = rescale_pypylog(pypylog, stats.get_runtime_in_microseconds())
         pypylog = filter_top_level_logs(pypylog)
         #for tid in list(c.threads.keys()):

--- a/vmprofconvert/__main__.py
+++ b/vmprofconvert/__main__.py
@@ -113,6 +113,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="vmprof-firefox-converter", description="convert vmprof profiles or run vmprof directly")
     parser.add_argument("-convert", metavar = "convert_file", dest = "convert_file", nargs = 1, help = "convert vmprof profile or zip")
     parser.add_argument("-jitlog", metavar = "jitlog_file", dest = "jitlog_file", nargs = 1, help = "use jitlog data")
+    parser.add_argument("-pypylog", metavar = "pypylog_file", dest = "pypylog_file", nargs = 1, help = "use pypylog data")
     parser.add_argument("-run", metavar = "python_file args", dest = "python_file", nargs = "+", help = "run vmprof and convert profile")
     parser.add_argument("--nobrowser", action = "store_false", dest = "browser", default = True, help = "dont open firefox profiler")
     parser.add_argument("--zip", action = "store_true", dest = "zip", default = False, help = "save profile as sharable zip file")
@@ -151,6 +152,8 @@ if __name__ == "__main__":
                 zip_path = path.replace(".prof", ".zip")
             if args.jitlog_file:
                 jitlogpath = os.path.abspath(args.jitlog_file[0])
+            if args.pypylog_file:
+                pypylogpath = os.path.abspath(args.pypylog_file[0])
             
     abspath = os.path.abspath(path)
 


### PR DESCRIPTION
This establishes feature-parity between `python -m vmprofconvert -run ...` and `python -m vmprof -o ...` followed by `vmprofconvert -convert`.